### PR TITLE
fix schema name for SQLite backend

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name='classic-migrations',
-    version='0.0.8',
+    version='0.0.9',
     description='Database migrations with SQL',
     long_description=open('README.rst').read(),
     long_description_content_type='text/x-rst',

--- a/sources/classic/migrations/backends/core/sqlite3.py
+++ b/sources/classic/migrations/backends/core/sqlite3.py
@@ -19,6 +19,7 @@ class SQLiteBackend(DatabaseBackend):
 
     driver_module = "sqlite3"
     list_tables_sql = "SELECT name FROM sqlite_master WHERE type = 'table'"
+    migrations_schema_name = "main"
 
     def connect(self, dburi):
         # Ensure that multiple connections share the same data


### PR DESCRIPTION
Переопределил поле migrations_schema_name значением "main" в классе SQLiteBackend, т.к. в БД SQLite есть только одна схема с именем main.